### PR TITLE
While testing with Paul I might have got distracted and found this bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.userprefs
 *.pidb
 *.booproj
+.DS_Store
 
 # Unity3D generated meta files
 *.pidb.meta

--- a/SpaceGame/Assets/Scripts/playerScript.cs
+++ b/SpaceGame/Assets/Scripts/playerScript.cs
@@ -234,6 +234,8 @@ public class playerScript : Photon.MonoBehaviour {
 			if (!enemy.isBattling) {
 				photonView.RPC("IsBattling", PhotonTargets.All, enemy.gameObject.GetPhotonView().viewID, true);
 				enemies.Add(enemy);
+			} else if (!enemies.Contains (enemy)) {
+				enemies.Add(enemy);
 			}
 		}
 		DoBattle(enemies);


### PR DESCRIPTION
I believe this is the fix to the bug I encountered.

Steps to reproduce:
- Enemy is beside a garison
- You move beside the enemy without moving into the garison
- You move into the garison (enemy should attack, but does not)
- You move from the garison onto a non-garison space (enemy should attack, but does not)
- Later: If you move from a non-garison onto the garison, even if the garison enemy is dead (enemy should attack, but does not)

When you move into a Garrison the Rampaging enemy won't attack, but their isBattling is set to "true".

Later, because their isBattling is already "true", they never get added to the combat.

(I'm not 100% sure, but I think the "isBattling" stuff can be replaced completely with this Contains check, but this is the safer change considering this is going into demo soon.)
